### PR TITLE
Remove header elements while preserving theme toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,10 +29,6 @@
     </button>
     
     <div class="container">
-        <header>
-            <h1>Course Materials Assistant</h1>
-            <p class="subtitle">Ask questions about courses, instructors, and content</p>
-        </header>
 
         <div class="main-content">
             <!-- Left Sidebar -->

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -122,26 +122,6 @@ body {
     transform: scale(0.5);
 }
 
-/* Header - Hidden */
-header {
-    display: none;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
 
 /* Main Content Area with Sidebar */
 .main-content {
@@ -791,13 +771,6 @@ details[open] .suggested-header::before {
         order: 1;
     }
     
-    header {
-        padding: 1rem;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
-    }
     
     .chat-messages {
         padding: 1rem;


### PR DESCRIPTION
Fixes #2

Removed the header elements as requested:
- Course Materials Assistant header
- Subheader about courses, instructors, and content
- Associated CSS styles

The theme toggle functionality remains preserved and properly positioned.

Generated with [Claude Code](https://claude.ai/code)